### PR TITLE
fixed cors cancer

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -38,8 +38,8 @@ import actionsRoute from './src/routes/actions.ts';
 
 // CORS options
 const corsOptions = {
-  origin: 'http://localhost:5173',
-  credentials: true,
+//  origin: 'http://localhost:5173', | the api is reverse proxied from nginx, so this does not work 
+  credentials: false,
   methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
   preflightContinue: false,
   optionsSuccessStatus: 204,
@@ -53,12 +53,13 @@ app.use(express.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
 app.use(cookieParser(process.env.COOKIE_PARSER_SECRET));
+/*
 app.use(session({
   secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: true
 }));
-
+*/
 
 
 app.use((req, res, next) => {


### PR DESCRIPTION
before:
```
$ curl -X POST -H "Content-Type: application/json" -d '{"chain": "polkadot", "msg": "hack the planet"}' http://localhost:8080/api/actions/system-remark   
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Error: secret option required for sessions<br> &nbsp; &nbsp;at session (/tmp/api_l/api/node_modules/express-session/index.js:204:12)<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/tmp/api_l/api/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at trim_prefix (/tmp/api_l/api/node_modules/express/lib/router/index.js:328:13)<br> &nbsp; &nbsp;at /tmp/api_l/api/node_modules/express/lib/router/index.js:286:9<br> &nbsp; &nbsp;at Function.process_params (/tmp/api_l/api/node_modules/express/lib/router/index.js:346:12)<br> &nbsp; &nbsp;at next (/tmp/api_l/api/node_modules/express/lib/router/index.js:280:10)<br> &nbsp; &nbsp;at cookieParser (/tmp/api_l/api/node_modules/cookie-parser/index.js:57:14)<br> &nbsp; &nbsp;at Layer.handle [as handle_request] (/tmp/api_l/api/node_modules/express/lib/router/layer.js:95:5)<br> &nbsp; &nbsp;at trim_prefix (/tmp/api_l/api/node_modules/express/lib/router/index.js:328:13)<br> &nbsp; &nbsp;at /tmp/api_l/api/node_modules/express/lib/router/index.js:286:9</pre>
</body>
</html>
```


after:
```
$ curl -X POST -H "Content-Type: application/json" -d '{"chain": "polkadot", "msg": "hack the planet"}' http://localhost:8080/api/actions/system-remark    -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying ::1:8080...
* Connected to localhost (::1) port 8080 (#0)
> POST /api/actions/system-remark HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.74.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 47
> 
* upload completely sent off: 47 out of 47 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Content-Type: application/json; charset=utf-8
< Content-Length: 55
< ETag: W/"37-KrCwRNAMewPIUFCxJa64ZBylYB8"
< Date: Wed, 15 May 2024 16:41:38 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
< 
* Connection #0 to host localhost left intact
{"result":"0x4c0400073c6861636b2074686520706c616e6574"}
```